### PR TITLE
Make it so you can paste binary strings into matrices

### DIFF
--- a/client/src/components/Decoder.tsx
+++ b/client/src/components/Decoder.tsx
@@ -61,7 +61,7 @@ const Decoder = ({
         {showPCM && (
           <DecoderItem
             title="PCM H"
-            matrixInput={<MatrixInput data={pcm} setData={setPcm} />}
+            matrixInput={<MatrixInput data={pcm} setData={setPcm} marshalPasteOfBinaryString={modulo == 2} />}
           />
         )}
         {showWord && (
@@ -73,6 +73,7 @@ const Decoder = ({
                 setData={setWord}
                 showRow={false}
                 showCol={false}
+                marshalPasteOfBinaryString={modulo == 2}
               />
             }
           />


### PR DESCRIPTION
For long binary strings, it's kind of annoying to have to type them by hand into the matrix field.

Update the `MatrixInput` component so if you paste a binary string  of the correct shape, it updates the array. Should save some future CO331 students lots of typing.

In a later PR we can add a UI tidbit explaining how to use this or something.


https://github.com/pl3lee/coding-theory-calculator/assets/6323857/b6ff12b2-999c-412c-9949-44d2fde96ad5


It also works for matrixes
https://github.com/pl3lee/coding-theory-calculator/assets/6323857/7b5a26e3-90cf-4bc5-84a7-ca19ce841cce

Right now it only works for binary strings (intentionally). I guess we can add more support later or something, if there's the desire for it.

https://github.com/pl3lee/coding-theory-calculator/assets/6323857/1c499368-1c27-45e4-9c4c-ab42b4cdd613

